### PR TITLE
Added support for cores outside of riscv-formal repository

### DIFF
--- a/checks/genchecks.py
+++ b/checks/genchecks.py
@@ -14,7 +14,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-import os, sys, shutil, re
+import os, sys, shutil, re, getopt
 
 nret = 1
 isa = "rv32i"
@@ -26,16 +26,36 @@ depths = list()
 blackbox = False
 
 cfgname = "checks"
-basedir = "%s/../.." % os.getcwd()
+basedir = "../.." # Assuming run from within riscv-formal/cores/<core>. Relative path for now.
 corename = os.getcwd().split("/")[-1]
 solver = "boolector"
 dumpsmt2 = False
 sbycmd = "sby"
 config = dict()
 
-if len(sys.argv) > 1:
-    assert len(sys.argv) == 2
-    cfgname = sys.argv[1]
+# Parse command-line options.
+
+def usage():
+    print("Usage: " + sys.argv[0] + " [--basedir <riscv-formal-repo-dir>] [<checks-dir>]")
+    sys.exit(1)
+
+try:
+    opts, argv = getopt.getopt(sys.argv[1:], "", ["basedir="])
+except getopt.GetoptError:
+    usage()
+for opt, val in opts:
+    if opt == "--basedir":
+        basedir = val
+if len(argv) > 1:
+    cfgname = argv[1]
+    if len(argv) > 2:
+        usage()
+
+# basedir must be absolute.
+if (basedir[0] != "/"):
+    basedir = "%s/%s" % (os.getcwd(), basedir)
+
+# Read config file.
 
 print("Reading %s.cfg." % cfgname)
 with open("%s.cfg" % cfgname, "r") as f:
@@ -263,7 +283,7 @@ def check_insn(insn, chanidx, csr_mode=False):
                     : `include "insn_@insn@.v"
             """, **hargs)
 
-with open("../../insns/isa_%s.txt" % isa) as isa_file:
+with open("%s/insns/isa_%s.txt" % (basedir, isa)) as isa_file:
     for insn in isa_file:
         for chanidx in range(nret):
             check_insn(insn.strip(), chanidx)


### PR DESCRIPTION
Hey, Clifford! I've incorporated riscv-formal runs into my WARP-V CI testing. These changes will help me clean up the process a bit. They let me run with riscv-formal as a submodule in the warp-v repo. All they do is make 'basedir' in genchecks configurable. Be aware that I'm new to Python.

I'm not sure how you would prefer to handle pull requests. I don't see a regression test, per se, but I ran pico and Vex with and without the change and got the same errors both ways :).

Sorry about my timing. I'm sure you are busy preparing for ORConf. I hope it goes well!